### PR TITLE
Add new feature of POST-and-GET test.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ export PYTHONPATH=.
 ```
 
 ### JSON File Format
-Put HTTP method as a top-level entry, and then specify your **api** and how you **test** it. It supports five HTTP methods, **GET**, **POST**, **PUT**, **PATCH** and **DELETE**. In the `api` part, you can set the target REST API by URL (`url`) with parameters (`params`). In the `test` part, you can add three types of test cases, timeout (`timeout`) in seconds, HTTP status code (`statusCode`) and [JSON Schema](http://json-schema.org) (`jsonSchema`).
+Put HTTP method as a top-level entry, and then specify your **api** and how you **test** it. It supports five HTTP methods, **GET**, **POST**, **PUT**, **PATCH** and **DELETE**. In the `api` part, you can set the target REST API by URL (`url`) with parameters (`params`). In the `tests` part, you can add three types of test cases, timeout (`timeout`) in seconds, HTTP status code (`statusCode`) and [JSON Schema](http://json-schema.org) (`jsonSchema`).
 
 The following example makes **GET** (`get`) API call to `http://json-server:3000/comments` with the `postId=1` parameter. When receiving the response, it checks the follows:
 
@@ -52,7 +52,7 @@ You can find some samples in [here](/samples) and [there](/test/function/resourc
 The `api` part consists of `url` and `params`. `url` is essential, but `params` is optional.
 
 #### params
-When parameter values are given as an array, multiple test cases with all possible parameter-sets are generated. They will show which parameter-set fails a test if exists (please see [5. Test Case Name](#5-test-case-name)). For example, the following parameters generate 9 test cases (e.g., `{"p1": 1, "p2": "abc", "p3": "def"}`):
+When parameter values are given as an array, multiple test cases with all possible parameter-sets are generated. They will show which parameter-set fails a test if exists (please see [5. Test Case Name](#5-test-case-name)). For example, the following parameters generate 9 different parameter sets. One of them could be `{"p1": 1, "p2": "abc", "p3": "def"}`.
 ```json
 "params": {
   "p1": [1, 2, 3],
@@ -89,6 +89,14 @@ You can build the four types of **Write-and-Read** test:
 - **DELETE-and-GET**
 
 Unlike the single-method test, **Write-and-Read** test builds always one test case to preserve test-execution order. Even when arrays of parameter values are given, this framework executes all the test cases belonging to **Write** method (e.g., **PUT**) first and then runs the test cases of **Read** method (e.g., **GET**).
+
+### POST-and-GET
+
+Your REST API may return the **Location** header of new resource which is created by a **POST** API call. In this case, you may want to **GET** the newly created resource using the **Location** header. To follow such use-scenario, just omit `get.api` in your test case. You can find the example in [here](test/function/resources/test_function_write_post_and_get_without_get_api.json).
+
+On the other hand, if you specify `get.api` in your **POST-and-GET** test, this framework will ignore the **Location** header and **GET** the `url` in the `get.api` like other **Write-and-Read** tests.
+
+The current version of this framework assumes that the **Location** header represents absolute URL ([RFC 2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html)). That is, it cannot recognize relative URL yet ([RFC 7231](https://tools.ietf.org/html/rfc7231#section-4.3.3)).
 
 ## 5. Test Case Name
 

--- a/rest_tester/function/read.py
+++ b/rest_tester/function/read.py
@@ -1,6 +1,3 @@
-import requests
-
-from rest_tester.setting import TestMethod, UnsupportedMethodError
 from . import TestFunctionBuilder
 
 
@@ -14,7 +11,5 @@ class ReadTestFunctionBuilder(TestFunctionBuilder):
 
     def _get_response(self, api, params, timeout):
         read_method = self._setting.method.read_method
-        if read_method == TestMethod.GET:
-            return requests.get(url=api.url, params=params, timeout=timeout)
-        else:
-            raise UnsupportedMethodError('Unsupported read method: %s' % read_method)
+
+        return self._send_request(method=read_method, url=api.url, params=params, timeout=timeout)

--- a/rest_tester/function/write.py
+++ b/rest_tester/function/write.py
@@ -1,7 +1,6 @@
-import requests
 import json
 
-from rest_tester.setting import TestMethod, UnsupportedMethodError
+from rest_tester.setting import TestMethod, ParameterSet
 from . import TestFunctionBuilder, TestFunction
 from .read import ReadTestFunctionBuilder
 
@@ -10,7 +9,10 @@ class WriteTestFunctionBuilder(TestFunctionBuilder):
     """Build function that checks the response from WRITE (e.g., PUT) method."""
     def build(self):
         if self._setting.method.read_method:
-            return self._build_write_and_read()
+            if self._setting.has_post_and_get_condition():
+                return self._build_post_and_get()
+            else:
+                return self._build_write_and_read()
         else:
             return self._build_write_only()
 
@@ -31,6 +33,33 @@ class WriteTestFunctionBuilder(TestFunctionBuilder):
         test_function_name = self._generate_name(self._name_prefix, write_api)
         return [TestFunction(test_function_name, test_function)]
 
+    def _build_post_and_get(self):
+        post_api = self._setting.write_api
+        post_tests = self._setting.write_tests
+        get_tests = self._setting.read_tests
+
+        test_function_list = []
+
+        param_set_list = ParameterSet.generate(post_api.params)
+        for param_set in param_set_list:
+
+            def test_function(test_self):
+                post_timeout = post_tests.timeout
+                post_response = self._get_response(post_api, param_set, post_timeout)
+
+                self.run_test(test_self, post_tests, post_response)
+
+                get_url = post_response.headers['Location']
+                get_timeout = get_tests.timeout
+                get_response = self._send_request(method=TestMethod.GET, url=get_url, params=None, timeout=get_timeout)
+
+                self.run_test(test_self, get_tests, get_response)
+
+            test_function_name = self._generate_name(self._name_prefix, post_api)
+            test_function_list.append(TestFunction(test_function_name, test_function))
+
+        return test_function_list
+
     def _build_write_only(self):
         write_api = self._setting.write_api
         write_tests = self._setting.write_tests
@@ -38,18 +67,7 @@ class WriteTestFunctionBuilder(TestFunctionBuilder):
         return self._build_test_function_list(write_api, write_tests)
 
     def _get_response(self, api, params, timeout):
-        url = api.url
         data = json.dumps(api.data) if api.data else None
-        headers = {'Content-Type': 'application/json'}
-
         write_method = self._setting.method.write_method
-        if write_method == TestMethod.PUT:
-            return requests.put(url=url, params=params, timeout=timeout, data=data, headers=headers)
-        elif write_method == TestMethod.POST:
-            return requests.post(url=url, params=params, timeout=timeout, data=data, headers=headers)
-        elif write_method == TestMethod.PATCH:
-            return requests.patch(url=url, params=params, timeout=timeout, data=data, headers=headers)
-        elif write_method == TestMethod.DELETE:
-            return requests.delete(url=url, params=params, timeout=timeout)
-        else:
-            raise UnsupportedMethodError('Unsupported read method: %s' % write_method)
+
+        return self._send_request(method=write_method, url=api.url, params=params, timeout=timeout, data=data)

--- a/rest_tester/setting/setting.py
+++ b/rest_tester/setting/setting.py
@@ -10,14 +10,8 @@ class TestSetting(object):
 
     def __init__(self, json_data):
         self._method = TestMethod(json_data)
-        read_method = self._method.read_method
         write_method = self._method.write_method
-
-        if read_method:
-            try:
-                self._read_api, self._read_tests = self._read_setting(json_data[read_method])
-            except KeyError:
-                raise SettingIncompleteInformationError('"%s" has incomplete information.' % read_method)
+        read_method = self._method.read_method
 
         if write_method:
             try:
@@ -25,9 +19,22 @@ class TestSetting(object):
             except KeyError:
                 raise SettingIncompleteInformationError('"%s" has incomplete information.' % write_method)
 
+        if read_method:
+            try:
+                self._read_api, self._read_tests = self._read_setting(json_data[read_method])
+            except KeyError:
+                raise SettingIncompleteInformationError('"%s" has incomplete information.' % read_method)
+
+            if self._read_api is None and not self.has_post_and_get_condition():
+                raise SettingIncompleteInformationError('"%s.%s" can be omitted only for POST-and-GET.' %
+                                                        (read_method, self.KEY_API))
+
     @classmethod
     def _read_setting(cls, json_data):
-        api = API(json_data[cls.KEY_API])
+        """API can be missing for POST-and-GET, but Tests should not be missing."""
+        api_data = json_data.get(cls.KEY_API)
+        api = API(api_data) if api_data else None
+
         tests = Tests(json_data[cls.KEY_TESTS])
 
         return api, tests
@@ -51,6 +58,12 @@ class TestSetting(object):
     @property
     def write_tests(self):
         return self._write_tests
+
+    def has_post_and_get_condition(self):
+        if self._read_api is None and self._method.write_method == TestMethod.POST:
+            return True
+        else:
+            return False
 
 
 class SettingIncompleteInformationError(Exception):

--- a/rest_tester/setting/setting.py
+++ b/rest_tester/setting/setting.py
@@ -60,10 +60,7 @@ class TestSetting(object):
         return self._write_tests
 
     def has_post_and_get_condition(self):
-        if self._read_api is None and self._method.write_method == TestMethod.POST:
-            return True
-        else:
-            return False
+        return self._read_api is None and self._method.write_method == TestMethod.POST
 
 
 class SettingIncompleteInformationError(Exception):

--- a/test/function/resources/test_function_write_post_and_get_without_get_api.json
+++ b/test/function/resources/test_function_write_post_and_get_without_get_api.json
@@ -1,0 +1,41 @@
+{
+  "post": {
+    "api": {
+      "url": "http://json-server:3000/posts",
+      "data": {
+        "title": "foo",
+        "body": "bar",
+        "userId": 1
+      }
+    },
+    "tests": {
+      "timeout" : 10,
+      "statusCode": 201
+    }
+  },
+  "get": {
+    "tests": {
+      "timeout" : 10,
+      "statusCode": 200,
+
+      "jsonSchema": {
+        "type": "object",
+
+        "properties": {
+          "userId": {
+            "type": "number"
+          },
+          "id": {
+            "type": "number"
+          },
+          "title": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/function/test_fail.py
+++ b/test/function/test_fail.py
@@ -9,12 +9,8 @@ class TestFailTestFunction(unittest.TestCase):
         builder = FailTestFunctionBuilder('Throw AssertionError!', 'fail test case')
         fail_function = builder.build()
 
-        try:
+        with self.assertRaises(AssertionError):
             fail_function.test_function(self)
-        except AssertionError:
-            pass
-        else:
-            self.fail('Should throw AssertionError!')
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/function/test_read.py
+++ b/test/function/test_read.py
@@ -23,34 +23,22 @@ class TestReadTestFunctionBuilder(unittest.TestCase):
         json_file = '%s/resources/test_function_read_get_unexpected_timeout.json' % self.current_dir_path
         test_function_list = self.generate_test_functions(json_file)
 
-        try:
+        with self.assertRaises(ReadTimeout):
             run_test_function_list(test_function_list, self)
-        except ReadTimeout:
-            pass
-        else:
-            self.fail('Should throw AssertionError!')
 
     def test_build_unexpected_status_code(self):
         json_file = '%s/resources/test_function_read_get_unexpected_status_code.json' % self.current_dir_path
         test_function_list = self.generate_test_functions(json_file)
 
-        try:
+        with self.assertRaises(AssertionError):
             run_test_function_list(test_function_list, self)
-        except AssertionError:
-            pass
-        else:
-            self.fail('Should throw AssertionError!')
 
     def test_build_unexpected_json_schema(self):
         json_file = '%s/resources/test_function_read_get_unexpected_json_schema.json' % self.current_dir_path
         test_function_list = self.generate_test_functions(json_file)
 
-        try:
+        with self.assertRaises(ValidationError):
             run_test_function_list(test_function_list, self)
-        except ValidationError:
-            pass
-        else:
-            self.fail('Should throw ValidationError!')
 
     @staticmethod
     def generate_test_functions(json_file):

--- a/test/function/test_write.py
+++ b/test/function/test_write.py
@@ -4,7 +4,7 @@ import unittest
 from jsonschema import ValidationError
 
 from rest_tester.function.write import WriteTestFunctionBuilder
-from rest_tester.setting import TestSetting
+from rest_tester.setting import TestSetting, SettingIncompleteInformationError
 from test.helper import load_json_data
 from . import run_test_function_list
 
@@ -44,6 +44,11 @@ class TestWriteTestFunctionBuilder(unittest.TestCase):
 
     def test_build_delete_only(self):
         json_file = '%s/resources/test_function_write_delete_only.json' % self.current_dir_path
+        test_function_list = self.generate_test_function(json_file)
+        run_test_function_list(test_function_list, self)
+
+    def test_build_post_and_get_without_get_api(self):
+        json_file = '%s/resources/test_function_write_post_and_get_without_get_api.json' % self.current_dir_path
         test_function_list = self.generate_test_function(json_file)
         run_test_function_list(test_function_list, self)
 

--- a/test/function/test_write.py
+++ b/test/function/test_write.py
@@ -56,23 +56,15 @@ class TestWriteTestFunctionBuilder(unittest.TestCase):
         json_file = '%s/resources/test_function_write_unexpected_status_code.json' % self.current_dir_path
         test_function_list = self.generate_test_function(json_file)
 
-        try:
+        with self.assertRaises(AssertionError):
             run_test_function_list(test_function_list, self)
-        except AssertionError:
-            pass
-        else:
-            self.fail('Should throw AssertionError')
 
     def test_build_unexpected_get(self):
         json_file = '%s/resources/test_function_write_unexpected_get.json' % self.current_dir_path
         test_function_list = self.generate_test_function(json_file)
 
-        try:
+        with self.assertRaises(ValidationError):
             run_test_function_list(test_function_list, self)
-        except ValidationError:
-            pass
-        else:
-            self.fail('Should throw ValidationError')
 
     @staticmethod
     def generate_test_function(json_file):

--- a/test/setting/resources/test_setting_post_and_get_without_get_api.json
+++ b/test/setting/resources/test_setting_post_and_get_without_get_api.json
@@ -1,0 +1,41 @@
+{
+  "post": {
+    "api": {
+      "url": "http://json-server:3000/posts",
+      "data": {
+        "title": "foo",
+        "body": "bar",
+        "userId": 1
+      }
+    },
+    "tests": {
+      "timeout" : 10,
+      "statusCode": 201
+    }
+  },
+  "get": {
+    "tests": {
+      "timeout" : 10,
+      "statusCode": 200,
+
+      "jsonSchema": {
+        "type": "object",
+
+        "properties": {
+          "userId": {
+            "type": "number"
+          },
+          "id": {
+            "type": "number"
+          },
+          "title": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/setting/resources/test_setting_put_and_get_without_get_api.json
+++ b/test/setting/resources/test_setting_put_and_get_without_get_api.json
@@ -1,0 +1,41 @@
+{
+  "put": {
+    "api": {
+      "url": "http://json-server:3000/posts",
+      "data": {
+        "title": "foo",
+        "body": "bar",
+        "userId": 1
+      }
+    },
+    "tests": {
+      "timeout" : 10,
+      "statusCode": 201
+    }
+  },
+  "get": {
+    "tests": {
+      "timeout" : 10,
+      "statusCode": 200,
+
+      "jsonSchema": {
+        "type": "object",
+
+        "properties": {
+          "userId": {
+            "type": "number"
+          },
+          "id": {
+            "type": "number"
+          },
+          "title": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/setting/test_api.py
+++ b/test/setting/test_api.py
@@ -40,12 +40,8 @@ class TestAPI(unittest.TestCase):
             }
         }
 
-        try:
+        with self.assertRaises(KeyError):
             API(request_data)
-        except KeyError:
-            pass
-        else:
-            self.fail('Should throw KeyError!')
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/setting/test_method.py
+++ b/test/setting/test_method.py
@@ -36,12 +36,8 @@ class TestTestMethod(unittest.TestCase):
             "remove": {}
         }
 
-        try:
+        with self.assertRaises(SettingMethodError):
             TestMethod(json_data)
-        except SettingMethodError:
-            pass
-        else:
-            self.fail('Should throw KeyError!')
 
     def test_three_methods(self):
         json_data = {
@@ -50,23 +46,15 @@ class TestTestMethod(unittest.TestCase):
             "put": {}
         }
 
-        try:
+        with self.assertRaises(SettingMethodError):
             TestMethod(json_data)
-        except SettingMethodError:
-            pass
-        else:
-            self.fail('Should throw KeyError!')
 
     def test_no_method(self):
         json_data = {
         }
 
-        try:
+        with self.assertRaises(SettingMethodError):
             TestMethod(json_data)
-        except SettingMethodError:
-            pass
-        else:
-            self.fail('Should throw KeyError!')
 
     def test_two_write_methods(self):
         json_data = {
@@ -74,12 +62,8 @@ class TestTestMethod(unittest.TestCase):
             "put": {}
         }
 
-        try:
+        with self.assertRaises(SettingMethodError):
             TestMethod(json_data)
-        except SettingMethodError:
-            pass
-        else:
-            self.fail('Should throw KeyError!')
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/setting/test_setting.py
+++ b/test/setting/test_setting.py
@@ -28,12 +28,8 @@ class TestTestSetting(unittest.TestCase):
         json_file = '%s/resources/test_setting_get_missing_response.json' % self.current_dir_path
         json_data = helper.load_json_data(json_file)
 
-        try:
+        with self.assertRaises(SettingIncompleteInformationError):
             TestSetting(json_data)
-        except SettingIncompleteInformationError:
-            pass
-        else:
-            self.fail('Should throw KeyError!')
 
     def test_post(self):
         json_file = '%s/resources/test_setting_post.json' % self.current_dir_path
@@ -78,12 +74,8 @@ class TestTestSetting(unittest.TestCase):
         json_file = '%s/resources/test_setting_post_missing_response.json' % self.current_dir_path
         json_data = helper.load_json_data(json_file)
 
-        try:
+        with self.assertRaises(SettingIncompleteInformationError):
             TestSetting(json_data)
-        except SettingIncompleteInformationError:
-            pass
-        else:
-            self.fail('Should throw KeyError!')
 
     def test_post_and_get_without_get_api(self):
         json_file = '%s/resources/test_setting_post_and_get_without_get_api.json' % self.current_dir_path
@@ -95,12 +87,8 @@ class TestTestSetting(unittest.TestCase):
         json_file = '%s/resources/test_setting_put_and_get_without_get_api.json' % self.current_dir_path
         json_data = helper.load_json_data(json_file)
 
-        try:
+        with self.assertRaises(SettingIncompleteInformationError):
             TestSetting(json_data)
-        except SettingIncompleteInformationError:
-            pass
-        else:
-            self.fail('Should throw KeyError!')
 
     @staticmethod
     def convert_api_to_dict(api):

--- a/test/setting/test_setting.py
+++ b/test/setting/test_setting.py
@@ -85,6 +85,23 @@ class TestTestSetting(unittest.TestCase):
         else:
             self.fail('Should throw KeyError!')
 
+    def test_post_and_get_without_get_api(self):
+        json_file = '%s/resources/test_setting_post_and_get_without_get_api.json' % self.current_dir_path
+        json_data = helper.load_json_data(json_file)
+
+        TestSetting(json_data)
+
+    def test_put_and_get_without_get_api(self):
+        json_file = '%s/resources/test_setting_put_and_get_without_get_api.json' % self.current_dir_path
+        json_data = helper.load_json_data(json_file)
+
+        try:
+            TestSetting(json_data)
+        except SettingIncompleteInformationError:
+            pass
+        else:
+            self.fail('Should throw KeyError!')
+
     @staticmethod
     def convert_api_to_dict(api):
         api_dict = {}

--- a/test/setting/test_tests.py
+++ b/test/setting/test_tests.py
@@ -6,7 +6,7 @@ from rest_tester.setting import Tests, SettingTestsError
 
 class TestTests(unittest.TestCase):
     def test_entire_information(self):
-        response_data = {
+        tests_data = {
             "timeout": 10,
             "statusCode": 200,
             "jsonSchema": {
@@ -19,23 +19,23 @@ class TestTests(unittest.TestCase):
             }
         }
 
-        response = Tests(response_data)
+        response = Tests(tests_data)
 
-        self.assertEqual(response_data[Tests.KEY_TIMEOUT], response.timeout)
-        self.assertEqual(response_data[Tests.KEY_STATUS_CODE], response.status_code)
-        self.assertEqual(response_data[Tests.KEY_JSON_SCHEMA], response.json_schema)
+        self.assertEqual(tests_data[Tests.KEY_TIMEOUT], response.timeout)
+        self.assertEqual(tests_data[Tests.KEY_STATUS_CODE], response.status_code)
+        self.assertEqual(tests_data[Tests.KEY_JSON_SCHEMA], response.json_schema)
 
     def test_essential_information(self):
-        response_data = {
+        tests_data = {
             "statusCode": 200
         }
 
-        response = Tests(response_data)
+        response = Tests(tests_data)
 
-        self.assertEqual(response_data[Tests.KEY_STATUS_CODE], response.status_code)
+        self.assertEqual(tests_data[Tests.KEY_STATUS_CODE], response.status_code)
 
     def test_wrong_key(self):
-        response_data = {
+        tests_data = {
             "wrongStatusCode": 200,
             "wrongJsonSchema": {
                 "type": "object",
@@ -47,12 +47,8 @@ class TestTests(unittest.TestCase):
             }
         }
 
-        try:
-            Tests(response_data)
-        except SettingTestsError:
-            pass
-        else:
-            self.fail('Should throw KeyError!')
+        with self.assertRaises(SettingTestsError):
+            Tests(tests_data)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -17,12 +17,8 @@ class TestMain(unittest.TestCase):
     def test_invalid_arguments(self):
         argv = ''
 
-        try:
+        with self.assertRaises(ValueError):
             main(argv)
-        except ValueError:
-            pass
-        else:
-            self.fail('Should thrown ValueError!')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
If `get.api` is omitted in POST-and-GET test, the framework will use the **Location** header of POST API call.